### PR TITLE
Add responsive layout and a11y enhancements

### DIFF
--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -32,6 +32,8 @@
     </mat-toolbar>
 
     <!-- routed views -->
-    <router-outlet></router-outlet>
+    <main class="page-container">
+      <router-outlet></router-outlet>
+    </main>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -1,18 +1,18 @@
-<h2 class="page-title">Register Student</h2>
+<h2 class="titulo-seccion">Registrar alumna</h2>
 
 <form [formGroup]="form" class="student-form" (ngSubmit)="save()">
   <mat-form-field appearance="outline">
-    <mat-label>Full Name</mat-label>
+    <mat-label>Nombre completo</mat-label>
     <input matInput formControlName="fullName" required />
   </mat-form-field>
 
   <mat-form-field appearance="outline">
-    <mat-label>Phone</mat-label>
+    <mat-label>Teléfono</mat-label>
     <input matInput formControlName="phone" required />
   </mat-form-field>
 
   <mat-form-field appearance="outline">
-    <mat-label>Email</mat-label>
+    <mat-label>Correo electrónico</mat-label>
     <input matInput formControlName="email" />
   </mat-form-field>
 

--- a/src/app/students/students.component.scss
+++ b/src/app/students/students.component.scss
@@ -1,11 +1,17 @@
-.page-title { margin-bottom: 1rem; font-family: 'Barlow Semi Condensed', sans-serif; }
+@use '../../styles/layout';
+
+.titulo-seccion { @extend %fluid-h2; }
 
 .student-form {
   display: grid;
-  gap: 1rem;
+  gap: layout.$space-2;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  margin-bottom: 2rem;
+  margin-block-end: layout.$space-3;
 }
 
 .mat-form-field { width: 100%; }
 table { width: 100%; }
+
+@container style(max-width: 480px) {
+  table { font-size: .85rem; }
+}

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { v4 as uuid } from 'uuid';
 
 import { StudentService } from '../services/student.service';
@@ -30,7 +31,9 @@ import { AsyncPipe } from '@angular/common';
 })
 export class StudentsComponent {
 
-  displayedColumns = ['fullName', 'phone', 'email', 'courseId', 'paidDeposit'];
+  displayedColumns = this.bp.isMatched(Breakpoints.Handset)
+    ? ['fullName','courseId','paidDeposit']
+    : ['fullName','phone','email','courseId','paidDeposit'];
 
   students$ = this.studentSvc.students$;
 
@@ -45,7 +48,8 @@ export class StudentsComponent {
   constructor(
     private fb: FormBuilder,
     private studentSvc: StudentService,
-    private sb: MatSnackBar
+    private sb: MatSnackBar,
+    private bp: BreakpointObserver
   ) {}
 
   save() {
@@ -56,7 +60,7 @@ export class StudentsComponent {
       createdAt: Date.now()
     };
     this.studentSvc.add(student);
-    this.sb.open('Student registered!', '', { duration: 2000 });
+    this.sb.open('Student registered!', '', { duration: 2000, panelClass: 'snack-fixed' });
     this.form.reset();
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,6 @@
 @use 'styles/rym-theme';            /* loads the theme */
+@use 'styles/layout';
+@use 'styles/a11y';
 
 /* gradient utility */
 .gradient-btn {

--- a/src/styles/_a11y.scss
+++ b/src/styles/_a11y.scss
@@ -1,0 +1,5 @@
+/* Visible focus ring (WCAG 2.2) */
+:focus-visible {
+  outline: 3px solid var(--mdc-theme-primary, #1D1E5B);
+  outline-offset: 2px;
+}

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -1,0 +1,23 @@
+/* Fluid spacing scale ------------------------------------------------------ */
+$space-0: 0;
+$space-1: clamp(.25rem, .4vw, .5rem);   // 4‑8 px
+$space-2: clamp(.5rem,  .8vw, 1rem);    // 8‑16 px
+$space-3: clamp(1rem,   1.6vw, 2rem);   // 16‑32 px
+
+/* Max‑width container (mobile‑first) --------------------------------------- */
+.page-container {
+  width: 100%;
+  max-width: 80rem;                     // 1280 px
+  margin-inline: auto;
+  padding-inline: $space-2;
+}
+
+/* Fluid typography helper -------------------------------------------------- */
+%fluid-h2 {
+  font-family: 'Barlow Semi Condensed', sans-serif;
+  font-size: clamp(1.4rem, 2.3vw + .6rem, 2.2rem);
+  margin-block: $space-2;
+}
+
+/* Snackbar fix for iOS notch ---------------------------------------------- */
+.snack-fixed { margin-bottom: env(safe-area-inset-bottom); }


### PR DESCRIPTION
## Summary
- create layout tokens for spacing and typography
- add global focus-visible style
- wrap routed views in container
- update students view with Spanish labels, grid layout, and container query
- adapt student table columns with BreakpointObserver
- include snackbar notch fix

## Testing
- `npx ng build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6876e54662c4833285b193f1d8e351ab