### PR TITLE
Fix sidebar active color

### DIFF
--- a/src/app/shell/shell.component.scss
+++ b/src/app/shell/shell.component.scss
@@ -2,7 +2,7 @@
 .flex-spacer       { flex: 1 1 auto; }
 .logo-bar          { justify-content: center; }
 
-/* Pink translucency when router marks an <a> as .active */
-:host ::ng-deep .mat-mdc-list-item.active {
+/* Highlight active nav item using the app accent */
+:host ::ng-deep .mat-mdc-nav-list .mdc-list-item--activated {
   background-color: rgba(#C54573, 0.15);
 }


### PR DESCRIPTION
## Summary
- ensure sidebar active item uses app accent

## Testing
- `npm run build`
- `npx ng test --watch=false` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6876f42d5d10833280aa8db718d1e2d2