### PR TITLE
Fix sidebar active state color

### DIFF
--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -7,16 +7,20 @@
     </mat-toolbar>
 
     <mat-nav-list>
-      <a mat-list-item routerLink="/dashboard" routerLinkActive="active">
+      <a mat-list-item routerLink="/dashboard" routerLinkActive="active"
+         #rlaDash="routerLinkActive" [activated]="rlaDash.isActive">
         <mat-icon>insights</mat-icon> Panel
       </a>
-      <a mat-list-item routerLink="/students" routerLinkActive="active">
+      <a mat-list-item routerLink="/students" routerLinkActive="active"
+         #rlaStudents="routerLinkActive" [activated]="rlaStudents.isActive">
         <mat-icon>group</mat-icon> Estudiantes
       </a>
-      <a mat-list-item routerLink="/courses" routerLinkActive="active">
+      <a mat-list-item routerLink="/courses" routerLinkActive="active"
+         #rlaCourses="routerLinkActive" [activated]="rlaCourses.isActive">
         <mat-icon>school</mat-icon> Cursos
       </a>
-      <a mat-list-item routerLink="/payments" routerLinkActive="active">
+      <a mat-list-item routerLink="/payments" routerLinkActive="active"
+         #rlaPayments="routerLinkActive" [activated]="rlaPayments.isActive">
         <mat-icon>credit_card</mat-icon> Pagos
       </a>
     </mat-nav-list>

--- a/src/app/shell/shell.component.scss
+++ b/src/app/shell/shell.component.scss
@@ -5,4 +5,6 @@
 /* Highlight active nav item using the app accent */
 :host ::ng-deep .mat-mdc-nav-list .mdc-list-item--activated {
   background-color: rgba(#C54573, 0.15);
+  --mdc-list-list-item-hover-state-layer-color: #C54573;
+  --mdc-list-list-item-focus-state-layer-color: #C54573;
 }


### PR DESCRIPTION
## Summary
- mark nav list items as `activated` when router link is active
- tune activated item styling so pink accent overrides grey layer

## Testing
- `npm run build`
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68770fceff0883328c6f73525fea9fe7