### PR TITLE
Fix CHROME_BIN for Angular Karma tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -84,6 +84,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "karmaConfig": "./karma.conf.mjs",
             "polyfills": [
               "zone.js",
               "zone.js/testing"

--- a/karma.conf.mjs
+++ b/karma.conf.mjs
@@ -1,0 +1,47 @@
+// Use Puppeteer’s Chromium in CI
+import puppeteer from 'puppeteer';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+process.env.CHROME_BIN = puppeteer.executablePath();
+
+export default function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageReporter: {
+      dir: path.join(__dirname, './coverage/rym-may'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
+    browsers: ['ChromeHeadlessNoSandbox'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+}


### PR DESCRIPTION
## Summary
- configure Karma to set `CHROME_BIN` using Puppeteer
- tell Angular CLI to use the new `karma.conf.mjs`

## Testing
- `npm test --silent` *(fails: Disconnected Client)*

------
https://chatgpt.com/codex/tasks/task_e_687716c68bc08332bd771f98f76817f2