### PR TITLE
Fix layout overflow on Students page

### DIFF
--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -30,6 +30,7 @@
 <!-- list -->
 <h3>Alumnas registradas</h3>
 
+<div class="table-container">
 <table mat-table [dataSource]="(students$ | async) || []" class="mat-elevation-z1">
 
   <ng-container matColumnDef="fullName">
@@ -62,3 +63,4 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row        *matRowDef="let row; columns: displayedColumns"></tr>
 </table>
+</div>

--- a/src/app/students/students.component.scss
+++ b/src/app/students/students.component.scss
@@ -10,6 +10,8 @@
 }
 
 .mat-form-field { width: 100%; }
+
+.table-container { overflow-x: auto; }
 table { width: 100%; }
 
 @container style(max-width: 480px) {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -10,6 +10,7 @@ $space-3: clamp(1rem,   1.6vw, 2rem);   // 16‑32 px
   max-width: 80rem;                     // 1280 px
   margin-inline: auto;
   padding-inline: $space-2;
+  box-sizing: border-box;
 }
 
 /* Fluid typography helper -------------------------------------------------- */


### PR DESCRIPTION
## Summary
- prevent padding from increasing `.page-container` width
- isolate table scroll in Students view
- define `.table-container` style to enable horizontal scrolling

## Testing
- `npm test` *(fails: Disconnected Client from Chrome Headless)*

------
https://chatgpt.com/codex/tasks/task_e_68772c471490833294d18f8d77718d51