### PR TITLE
Fix responsive columns with SSR hydration

### DIFF
--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -60,7 +60,7 @@
     </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row        *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns$ | async"></tr>
+  <tr mat-row        *matRowDef="let row; columns: displayedColumns$ | async"></tr>
 </table>
 </div>

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { map, startWith } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
 import { StudentService } from '../services/student.service';
@@ -31,9 +32,21 @@ import { AsyncPipe } from '@angular/common';
 })
 export class StudentsComponent {
 
-  displayedColumns = this.bp.isMatched(Breakpoints.Handset)
-    ? ['fullName','courseId','paidDeposit']
-    : ['fullName','phone','email','courseId','paidDeposit'];
+  private readonly handsetCols = ['fullName', 'courseId', 'paidDeposit'] as const;
+  private readonly desktopCols = [
+    'fullName',
+    'phone',
+    'email',
+    'courseId',
+    'paidDeposit',
+  ] as const;
+
+  displayedColumns$ = this.bp
+    .observe(Breakpoints.Handset)
+    .pipe(
+      map((r) => (r.matches ? this.handsetCols : this.desktopCols)),
+      startWith(this.desktopCols)
+    );
 
   students$ = this.studentSvc.students$;
 


### PR DESCRIPTION
## Summary
- compute student table columns using BreakpointObserver observable
- update template to consume column list asynchronously

## Testing
- `npm test` *(fails: AppComponent should render title)*

------
https://chatgpt.com/codex/tasks/task_e_6877720e7d84833283499878400e0ec0