### PR TITLE
Add responsive course listings

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,10 +20,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('rym-may');
   });
 
-  it('should render title', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, rym-may');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,6 +17,11 @@ export const routes: Routes = [
         loadComponent: () => import('./students/students.component')
                             .then(m => m.StudentsComponent)
       },
+      {
+        path: 'courses',
+        loadComponent: () => import('./courses/courses.component')
+                            .then(m => m.CoursesComponent)
+      },
     ]
   },
 

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -1,0 +1,19 @@
+<h2 class="titulo" [class.handset]="isHandset">Nuestros cursos</h2>
+
+<section class="grid">
+  <mat-card class="curso" *ngFor="let c of cursos">
+    <img mat-card-image [src]="c.imagen" [alt]="c.nombre" />
+    <mat-card-header>
+      <mat-card-title>{{ c.nombre }}</mat-card-title>
+      <mat-card-subtitle>{{ c.duracion }} • {{ c.precio }}</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <p>{{ c.descripcion }}</p>
+    </mat-card-content>
+
+    <mat-card-actions>
+      <button mat-raised-button color="accent">Inscribirme</button>
+    </mat-card-actions>
+  </mat-card>
+</section>

--- a/src/app/courses/courses.component.scss
+++ b/src/app/courses/courses.component.scss
@@ -1,0 +1,21 @@
+@use '../../styles/layout';
+
+.titulo { @extend %fluid-h2; text-align: center; }
+.titulo.handset { font-size: clamp(1.2rem, 2vw + .5rem, 1.8rem); }
+
+.grid {
+  display: grid;
+  gap: layout.$space-2;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  padding-block: layout.$space-3;
+}
+
+.curso {
+  img { height: 160px; object-fit: cover; }
+  mat-card-header { background-color: rgb(29,30,91); color: #fff; }
+  button { margin-top: layout.$space-1; }
+}
+
+@container style(max-width: 320px) {
+  .curso { font-size: .9rem; }
+}

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { Course } from '../models/course.model';
+import { MOCK_COURSES } from '../models/mock-courses';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+
+@Component({
+  selector: 'app-courses',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatButtonModule],
+  templateUrl: './courses.component.html',
+  styleUrl: './courses.component.scss'
+})
+export class CoursesComponent {
+  cursos: Course[] = MOCK_COURSES;
+  isHandset = this.bp.isMatched(Breakpoints.Handset);
+  constructor(private bp: BreakpointObserver) {}
+}

--- a/src/app/models/course.model.ts
+++ b/src/app/models/course.model.ts
@@ -1,0 +1,8 @@
+export interface Course {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  duracion: string;   // e.g. "2 días"
+  precio: string;     // "MX$ 3 500"
+  imagen: string;     // assets path
+}

--- a/src/app/models/mock-courses.ts
+++ b/src/app/models/mock-courses.ts
@@ -1,0 +1,28 @@
+import { Course } from './course.model';
+
+export const MOCK_COURSES: Course[] = [
+  {
+    id: '1',
+    nombre: 'Extensiones de pestañas – Básico',
+    descripcion: 'Aprende la técnica clásica para aplicar extensiones de pestañas con seguridad y precisión.',
+    duracion: '2 días',
+    precio: 'MX$\u00a03\u00a0500',
+    imagen: 'https://picsum.photos/seed/pestanas/280/160'
+  },
+  {
+    id: '2',
+    nombre: 'Uñas acrílicas – Intermedio',
+    descripcion: 'Perfecciona esculpido, limado y decoración bajo la guía de nuestras instructoras.',
+    duracion: '3 días',
+    precio: 'MX$\u00a04\u00a0200',
+    imagen: 'https://picsum.photos/seed/unasin/280/160'
+  },
+  {
+    id: '3',
+    nombre: 'Nanoplastia capilar',
+    descripcion: 'Certifícate en el alisado más avanzado de la línea Rym\u00a0May Nanoplastia\u00a095\u00a0%.',
+    duracion: '1 día',
+    precio: 'MX$\u00a05\u00a0800',
+    imagen: 'https://picsum.photos/seed/nanoplastia/280/160'
+  }
+];


### PR DESCRIPTION
## Summary
- list course data via new `Course` model and mock array
- show courses in a new component with responsive cards
- include route `/courses` and update tests
- add placeholder images for courses
- switch course images to external URLs and remove local copies

## Testing
- `npm ci`
- `CHROME_BIN=$(node -e "const p=require('puppeteer'); console.log(p.executablePath())") CHROME_FLAGS="--no-sandbox" npx ng test --watch=false --progress=false`
- `npx ng build`


------
https://chatgpt.com/codex/tasks/task_e_6877b1897b1c833286faed843c8497cf