### PR TITLE
Implement course & student admin features

### DIFF
--- a/src/app/course.service.spec.ts
+++ b/src/app/course.service.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { CourseService } from './services/course.service';
+import { Course } from './models/course.model';
+
+describe('CourseService', () => {
+  let service: CourseService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CourseService);
+  });
+
+  it('should perform basic CRUD', () => {
+    expect(service.findAll().length).toBe(0);
+
+    const c: Course = {id: '1', nombre: 'n', descripcion: 'd', duracion: '1', precio: '$', imagen: ''};
+    service.create(c);
+    expect(service.findAll().length).toBe(1);
+
+    service.update({...c, nombre: 'mod'});
+    expect(service.findAll()[0].nombre).toBe('mod');
+
+    service.remove('1');
+    expect(service.findAll().length).toBe(0);
+  });
+});

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -1,7 +1,9 @@
 <h2 class="titulo" [class.handset]="isHandset">Nuestros cursos</h2>
-
-<section class="grid">
-  <mat-card class="curso" *ngFor="let c of cursos">
+<button mat-fab color="accent" class="fab" aria-label="Nuevo curso" (click)="nuevo()">
+  <mat-icon>add</mat-icon>
+</button>
+<section class="grid slider">
+  <mat-card class="curso" *ngFor="let c of cursos$ | async">
     <img mat-card-image [src]="c.imagen" [alt]="c.nombre" />
     <mat-card-header>
       <mat-card-title>{{ c.nombre }}</mat-card-title>
@@ -14,6 +16,13 @@
 
     <mat-card-actions>
       <button mat-raised-button color="accent">Inscribirme</button>
+      <span class="grow"></span>
+      <button mat-icon-button aria-label="Editar curso" (click)="editar(c)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" aria-label="Eliminar curso" (click)="eliminar(c.id)">
+        <mat-icon>delete</mat-icon>
+      </button>
     </mat-card-actions>
   </mat-card>
 </section>

--- a/src/app/courses/courses.component.scss
+++ b/src/app/courses/courses.component.scss
@@ -8,14 +8,53 @@
   gap: layout.$space-2;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   padding-block: layout.$space-3;
+  position: relative;
 }
 
 .curso {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   img { height: 160px; object-fit: cover; }
-  mat-card-header { background-color: rgb(29,30,91); color: #fff; }
+  mat-card-header {
+    background-color: rgb(29,30,91);
+    color: #fff;
+    .mat-card-subtitle { color: #fff; }
+  }
+  mat-card-content {
+    flex: 1 1 auto;
+    p {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+  mat-card-actions { margin-top: auto; }
   button { margin-top: layout.$space-1; }
+  &:hover, &:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 6px 20px rgba(0,0,0,.25);
+    transition: .25s;
+  }
+}
+
+.fab {
+  position: absolute;
+  top: layout.$space-2;
+  right: layout.$space-2;
+  z-index: 2;
 }
 
 @container style(max-width: 320px) {
   .curso { font-size: .9rem; }
 }
+
+@media (max-width:599px){
+  .slider{ display:flex; gap:layout.$space-2; overflow-x:auto; scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch;
+    .curso{ min-width:75%; scroll-snap-align:start; }
+  }
+  .slider::after{ content:''; flex:0 0 15%; }
+}
+
+.grow{ flex:1 1 auto; }

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -2,19 +2,44 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { Course } from '../models/course.model';
-import { MOCK_COURSES } from '../models/mock-courses';
+import { CourseService } from '../services/course.service';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { MatDialog } from '@angular/material/dialog';
+import { v4 as uuid } from 'uuid';
+import { CourseFormComponent } from '../dialogs/course-form/course-form.component';
 
 @Component({
   selector: 'app-courses',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule],
   templateUrl: './courses.component.html',
   styleUrl: './courses.component.scss'
 })
 export class CoursesComponent {
-  cursos: Course[] = MOCK_COURSES;
+  cursos$ = this.courseSvc.courses$;
   isHandset = this.bp.isMatched(Breakpoints.Handset);
-  constructor(private bp: BreakpointObserver) {}
+
+  constructor(
+    private bp: BreakpointObserver,
+    private courseSvc: CourseService,
+    private dialog: MatDialog
+  ) {}
+
+  nuevo() {
+    this.dialog.open(CourseFormComponent, { autoFocus: false })
+      .afterClosed()
+      .subscribe(res => { if (res) this.courseSvc.create({ ...res, id: uuid() }); });
+  }
+
+  editar(c: Course) {
+    this.dialog.open(CourseFormComponent, { data: c, autoFocus: false })
+      .afterClosed()
+      .subscribe(res => { if (res) this.courseSvc.update(res); });
+  }
+
+  eliminar(id: string) {
+    this.courseSvc.remove(id);
+  }
 }

--- a/src/app/dialogs/confirm-dialog.component.ts
+++ b/src/app/dialogs/confirm-dialog.component.ts
@@ -1,0 +1,25 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Confirmar</h2>
+    <p class="msg">{{ data }}</p>
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancelar</button>
+      <button mat-raised-button color="warn" (click)="ok()">Eliminar</button>
+    </div>
+  `,
+  styles: [`.msg{margin:1rem 0;}`]
+})
+export class ConfirmDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: string,
+    private dialogRef: MatDialogRef<ConfirmDialogComponent>
+  ){}
+  ok(){ this.dialogRef.close(true); }
+}

--- a/src/app/dialogs/course-form/course-form.component.html
+++ b/src/app/dialogs/course-form/course-form.component.html
@@ -1,0 +1,34 @@
+<form [formGroup]="form" class="course-form" (ngSubmit)="save()">
+  <mat-form-field appearance="outline">
+    <mat-label>Nombre</mat-label>
+    <input matInput formControlName="nombre" required />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Descripci\u00f3n</mat-label>
+    <textarea matInput formControlName="descripcion" rows="3" required></textarea>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Duraci\u00f3n</mat-label>
+    <input matInput formControlName="duracion" required />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Precio</mat-label>
+    <input matInput formControlName="precio" required />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Imagen URL</mat-label>
+    <input matInput formControlName="imagen" pattern="https?://.*" />
+  </mat-form-field>
+
+  <input type="file" accept="image/*" (change)="fileSelected($event)" />
+  <img *ngIf="preview" [src]="preview" alt="Previsualizaci\u00f3n" class="preview" />
+
+  <div class="acciones">
+    <button mat-button mat-dialog-close>Cancelar</button>
+    <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid">Guardar</button>
+  </div>
+</form>

--- a/src/app/dialogs/course-form/course-form.component.scss
+++ b/src/app/dialogs/course-form/course-form.component.scss
@@ -1,0 +1,19 @@
+@use '../../styles/layout';
+
+.course-form {
+  display: grid;
+  gap: layout.$space-2;
+  width: 320px;
+}
+
+.preview {
+  width: 100%;
+  height: auto;
+  margin-block-end: layout.$space-2;
+}
+
+.acciones {
+  display: flex;
+  justify-content: flex-end;
+  gap: layout.$space-1;
+}

--- a/src/app/dialogs/course-form/course-form.component.ts
+++ b/src/app/dialogs/course-form/course-form.component.ts
@@ -1,0 +1,59 @@
+import { Component, Inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { Course } from '../../models/course.model';
+
+@Component({
+  selector: 'app-course-form',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+  ],
+  templateUrl: './course-form.component.html',
+  styleUrls: ['./course-form.component.scss']
+})
+export class CourseFormComponent {
+  preview: string | null = null;
+  form = this.fb.group({
+    nombre: ['', Validators.required],
+    descripcion: ['', Validators.required],
+    duracion: ['', Validators.required],
+    precio: ['', Validators.required],
+    imagen: ['']
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<CourseFormComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Course | null,
+  ) {
+    if (data) {
+      this.form.patchValue(data);
+      this.preview = data.imagen;
+    }
+  }
+
+  fileSelected(ev: Event) {
+    const input = ev.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const file = input.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.preview = reader.result as string;
+      this.form.patchValue({ imagen: this.preview });
+    };
+    reader.readAsDataURL(file);
+  }
+
+  save() {
+    if (this.form.invalid) return;
+    this.dialogRef.close({ ...this.data, ...this.form.value } as Course);
+  }
+}

--- a/src/app/dialogs/student-edit-dialog.component.ts
+++ b/src/app/dialogs/student-edit-dialog.component.ts
@@ -1,0 +1,58 @@
+import { Component, Inject } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-student-edit-dialog',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatCheckboxModule,
+    MatButtonModule,
+  ],
+  template: `
+    <h2 mat-dialog-title>Editar alumna</h2>
+    <form [formGroup]="form" class="student-form" (ngSubmit)="save()">
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre completo</mat-label>
+        <input matInput formControlName="fullName" required />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Teléfono</mat-label>
+        <input matInput formControlName="phone" required />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Correo electrónico</mat-label>
+        <input matInput formControlName="email" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>ID del curso</mat-label>
+        <input matInput formControlName="courseId" />
+      </mat-form-field>
+      <mat-checkbox formControlName="paidDeposit">Depósito pagado</mat-checkbox>
+
+      <div mat-dialog-actions align="end">
+        <button mat-button mat-dialog-close>Cancelar</button>
+        <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid">Guardar</button>
+      </div>
+    </form>
+  `,
+  styles: [`.student-form{display:grid;gap:.5rem;width:300px}`]
+})
+export class StudentEditDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public form: FormGroup,
+    private dialogRef: MatDialogRef<StudentEditDialogComponent>
+  ) {}
+
+  save(){
+    this.dialogRef.close(this.form.value);
+  }
+}

--- a/src/app/services/course.service.ts
+++ b/src/app/services/course.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Course } from '../models/course.model';
+
+const LS_KEY = 'rm_courses';
+
+@Injectable({ providedIn: 'root' })
+export class CourseService {
+  private store$ = new BehaviorSubject<Course[]>(this.loadLS());
+  courses$ = this.store$.asObservable();
+
+  findAll(): Course[] {
+    return this.store$.value;
+  }
+
+  create(course: Course) {
+    const next = [...this.store$.value, course];
+    this.persist(next);
+  }
+
+  update(course: Course) {
+    const next = this.store$.value.map(c => c.id === course.id ? course : c);
+    this.persist(next);
+  }
+
+  remove(id: string) {
+    const next = this.store$.value.filter(c => c.id !== id);
+    this.persist(next);
+  }
+
+  // ---------- private ----------
+  private persist(list: Course[]) {
+    localStorage.setItem(LS_KEY, JSON.stringify(list));
+    this.store$.next(list);
+  }
+
+  private loadLS(): Course[] {
+    try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]'); }
+    catch { return []; }
+  }
+}

--- a/src/app/services/student.service.ts
+++ b/src/app/services/student.service.ts
@@ -20,6 +20,16 @@ export class StudentService {
   /** util for demo edit/remove if needed later */
   update(list: Student[]) { this.persist(list); }
 
+  edit(student: Student) {
+    const next = this.store$.value.map(s => s.id === student.id ? student : s);
+    this.persist(next);
+  }
+
+  remove(id: string) {
+    const next = this.store$.value.filter(s => s.id !== id);
+    this.persist(next);
+  }
+
 
   // ---------- private ----------
   private persist(list: Student[]) {

--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -71,6 +71,18 @@
     </td>
   </ng-container>
 
+  <ng-container matColumnDef="acciones">
+    <th mat-header-cell *matHeaderCellDef>Acciones</th>
+    <td mat-cell *matCellDef="let s">
+      <button mat-icon-button aria-label="Editar alumna" (click)="editar(s)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" aria-label="Eliminar alumna" (click)="eliminar(s.id)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row        *matRowDef="let row; columns: displayedColumns"></tr>
 </table>

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -33,8 +33,8 @@ import { AsyncPipe } from '@angular/common';
 })
 export class StudentsComponent {
 
-  displayedColumnsHandset = ['fullName','courseId','factura'] as const;
-  displayedColumnsDesktop = ['fullName','phone','email','courseId','paidDeposit','factura'] as const;
+  displayedColumnsHandset = ['fullName','courseId','factura','acciones'] as const;
+  displayedColumnsDesktop = ['fullName','phone','email','courseId','paidDeposit','factura','acciones'] as const;
   displayedColumns = this.bp.isMatched(Breakpoints.Handset)
     ? this.displayedColumnsHandset : this.displayedColumnsDesktop;
 
@@ -74,5 +74,26 @@ export class StudentsComponent {
     this.studentSvc.add(student);
     this.sb.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-fixed' });
     this.form.reset();
+  }
+
+  editar(alumna: Student) {
+    const form = this.fb.group({
+      fullName: [alumna.fullName, [Validators.required, Validators.minLength(3)]],
+      phone:    [alumna.phone, Validators.required],
+      email:    [alumna.email, [Validators.email]],
+      courseId: [alumna.courseId, Validators.required],
+      paidDeposit: [alumna.paidDeposit]
+    });
+
+    this.dialog.open(StudentEditDialogComponent, { data: form, autoFocus: false })
+      .afterClosed()
+      .subscribe(res => {
+        if (res) this.studentSvc.edit({ ...alumna, ...res });
+      });
+  }
+
+  eliminar(id: string) {
+    const ref = this.dialog.open(ConfirmDialogComponent, { data: '¿Eliminar alumna?', autoFocus: false });
+    ref.afterClosed().subscribe(ok => { if (ok) this.studentSvc.remove(id); });
   }
 }


### PR DESCRIPTION
## Summary
- add CourseService with localStorage persistence
- create CourseForm dialog for creating/updating courses
- integrate CourseService into CoursesComponent with add/edit/delete actions
- enable mobile slider and style polish for course cards
- extend StudentService with edit & remove
- add dialogs for student edit and delete confirmation
- include basic CourseService unit test

## Testing
- `npm install --ignore-scripts`
- `./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ddaac657483328ff49e39ba476165