### PR TITLE
Add reusable dialog skin for consistent spacing

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -30,6 +30,7 @@ export class CoursesComponent {
   nuevo() {
     this.dialog.open(CourseFormComponent, {
       data: null,
+      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
       width: '720px',
       maxWidth: '95vw',
       autoFocus: true
@@ -41,6 +42,7 @@ export class CoursesComponent {
   editar(c: Course) {
     this.dialog.open(CourseFormComponent, {
       data: c,
+      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
       width: '720px',
       maxWidth: '95vw',
       autoFocus: true

--- a/src/app/dialogs/course-form/course-form.component.scss
+++ b/src/app/dialogs/course-form/course-form.component.scss
@@ -1,13 +1,5 @@
 @use '../../../styles/layout';
 
-.dialog-title{
-  font-family: 'Barlow Semi Condensed', sans-serif;
-  font-weight: 700;
-  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.6rem);
-  color: #1D1E5B;
-}
-.dialog-content{ padding: layout.$space-2; }
-
 .grid{
   display: grid;
   gap: layout.$space-2;
@@ -25,12 +17,6 @@
 }
 
 @media (max-width: 640px){ .grid{ grid-template-columns: 1fr; } }
-
-.dialog-actions{
-  position: sticky; bottom: 0; background: #fff;
-  padding: layout.$space-2; margin: 0 -24px -8px;
-  border-top: 1px solid rgba(0,0,0,.06);
-}
 
 /* subtle field affordance */
 .mat-mdc-form-field:hover{ filter: brightness(.98); transition: filter .15s; }

--- a/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.scss
+++ b/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.scss
@@ -1,13 +1,5 @@
 @use '../../../styles/layout';
 
-.dialog-title{
-  font-family: 'Barlow Semi Condensed', sans-serif;
-  font-weight: 700;
-  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.6rem);
-  color: #1D1E5B;
-}
-.dialog-content{ padding: layout.$space-2; }
-
 .grid{
   display: grid;
   gap: layout.$space-2;
@@ -16,5 +8,3 @@
 .full-row{ grid-column: 1 / -1; }
 
 @media (max-width: 640px){ .grid{ grid-template-columns: 1fr; } }
-
-.dialog-actions{ padding: layout.$space-2; }

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -81,8 +81,9 @@ export class StudentsComponent {
   editar(row: Student) {
     this.dialog.open(StudentEditDialogComponent, {
       data: { ...row },
+      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
       width: '720px',
-      maxWidth: '92vw',
+      maxWidth: '95vw',
       autoFocus: true
     }).afterClosed().subscribe(result => {
       if (result) this.studentSvc.edit(result as Student);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,8 @@
 @use 'styles/rym-theme';            /* loads the theme */
 @use 'styles/layout';
 @use 'styles/a11y';
+/* Import the new dialog skin (after theme/layout) */
+@use 'styles/dialog';
 
 /* gradient utility */
 .gradient-btn {

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -1,0 +1,40 @@
+@use './layout';
+
+.rm-dialog {
+  /* Title uses brand font and leaves space below it */
+  .mat-mdc-dialog-title,
+  .dialog-title {
+    display: block;
+    margin: 0 0 layout.$space-2;
+    font-family: 'Barlow Semi Condensed', sans-serif;
+    font-weight: 700;
+    font-size: clamp(1.25rem, 1.2vw + 1rem, 1.6rem);
+    color: #1D1E5B;
+  }
+
+  /* Content gets top padding + bounded height with scroll */
+  .mat-mdc-dialog-content,
+  .dialog-content {
+    display: block;
+    padding: layout.$space-2;
+    max-height: min(72vh, 72dvh);
+    overflow: auto;
+    scrollbar-gutter: stable both-edges;
+  }
+
+  /* Sticky action bar so primary buttons are always visible */
+  .mat-mdc-dialog-actions,
+  .dialog-actions {
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    padding: layout.$space-2;
+    margin: 0 -24px -8px;
+    border-top: 1px solid rgba(0,0,0,.06);
+    z-index: 1;
+  }
+
+  /* Field rhythm */
+  .mat-mdc-form-field { width: 100%; }
+  .mat-mdc-form-field + .mat-mdc-form-field { margin-top: layout.$space-2; }
+}


### PR DESCRIPTION
## Summary
- create global dialog skin in `styles/_dialog.scss`
- import the dialog styles globally
- open CourseForm and StudentEdit dialogs with `panelClass: 'rm-dialog'`
- remove local dialog spacing styles from course and student dialogs

## Testing
- `npm test` *(fails: ChromeHeadless could not launch)*

------
https://chatgpt.com/codex/tasks/task_e_6886bffbde34833283803299012acc03