### PR TITLE
Fix dialog content padding

### DIFF
--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -16,10 +16,17 @@
   .mat-mdc-dialog-content,
   .dialog-content {
     display: block;
-    padding: layout.$space-2;
+    /* Extra top padding prevents outline labels from clipping under the title */
+    padding: layout.$space-3 layout.$space-2 layout.$space-2;
     max-height: min(72vh, 72dvh);
     overflow: auto;
     scrollbar-gutter: stable both-edges;
+  }
+
+  /* Guarantee extra clearance for the very first field in the form/grid */
+  .dialog-content form > .mat-mdc-form-field:first-of-type,
+  .dialog-content .grid > .mat-mdc-form-field:first-of-type {
+    margin-top: layout.$space-1;
   }
 
   /* Sticky action bar so primary buttons are always visible */


### PR DESCRIPTION
## Summary
- adjust shared dialog padding so first field labels don't get clipped
- ensure first form field has a little margin on top

## Testing
- `npm test --silent` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6886d089f0e88332b54343ad91ca43e2