### PR TITLE
Implement placeholder image and CRUD improvements

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { Course } from '../models/course.model';
 import { CourseService } from '../services/course.service';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
@@ -13,7 +14,7 @@ import { CourseFormComponent } from '../dialogs/course-form/course-form.componen
 @Component({
   selector: 'app-courses',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatSnackBarModule],
   templateUrl: './courses.component.html',
   styleUrl: './courses.component.scss'
 })
@@ -24,7 +25,8 @@ export class CoursesComponent {
   constructor(
     private bp: BreakpointObserver,
     private courseSvc: CourseService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private snack: MatSnackBar
   ) {}
 
   nuevo() {
@@ -36,7 +38,12 @@ export class CoursesComponent {
       autoFocus: true
     })
       .afterClosed()
-      .subscribe(res => { if (res) this.courseSvc.create({ ...res, id: uuid() }); });
+      .subscribe(res => {
+        if (res) {
+          this.courseSvc.create({ ...res, id: uuid() });
+          this.snack.open('Curso creado', '', { duration: 1800 });
+        }
+      });
   }
 
   editar(c: Course) {
@@ -48,7 +55,12 @@ export class CoursesComponent {
       autoFocus: true
     })
       .afterClosed()
-      .subscribe(res => { if (res) this.courseSvc.update(res); });
+      .subscribe(res => {
+        if (res) {
+          this.courseSvc.update(res);
+          this.snack.open('Curso actualizado', '', { duration: 1800 });
+        }
+      });
   }
 
   eliminar(id: string) {

--- a/src/app/services/course.service.ts
+++ b/src/app/services/course.service.ts
@@ -3,26 +3,49 @@ import { BehaviorSubject } from 'rxjs';
 import { Course } from '../models/course.model';
 
 const LS_KEY = 'rm_courses';
+const PLACEHOLDER = 'assets/placeholder-course.svg';
 
 @Injectable({ providedIn: 'root' })
 export class CourseService {
   private store$ = new BehaviorSubject<Course[]>(this.loadLS());
+  /** Public stream for components that use | async */
   courses$ = this.store$.asObservable();
 
-  findAll(): Course[] {
-    return this.store$.value;
-  }
+  findAll(): Course[] { return this.store$.value; }
 
+  /** Create a new course (assigns placeholder image if empty) */
   create(course: Course) {
-    const next = [...this.store$.value, course];
+    const next = [...this.store$.value];
+    const exists = next.some(c => c.id === course.id);
+    const nuevo: Course = {
+      ...course,
+      imagen: (course.imagen && course.imagen.trim()) ? course.imagen : PLACEHOLDER
+    };
+    if (exists) {
+      // If the id already exists, treat as update to avoid duplicates.
+      const idx = next.findIndex(c => c.id === course.id);
+      next[idx] = { ...next[idx], ...nuevo };
+    } else {
+      next.unshift(nuevo);
+    }
     this.persist(next);
   }
 
+  /** Update by id */
   update(course: Course) {
-    const next = this.store$.value.map(c => c.id === course.id ? course : c);
-    this.persist(next);
+    const next = [...this.store$.value];
+    const idx = next.findIndex(c => c.id === course.id);
+    if (idx >= 0) {
+      next[idx] = {
+        ...next[idx],
+        ...course,
+        imagen: (course.imagen && course.imagen.trim()) ? course.imagen : next[idx].imagen || PLACEHOLDER
+      };
+      this.persist(next);
+    }
   }
 
+  /** Remove by id */
   remove(id: string) {
     const next = this.store$.value.filter(c => c.id !== id);
     this.persist(next);
@@ -30,10 +53,9 @@ export class CourseService {
 
   // ---------- private ----------
   private persist(list: Course[]) {
-    localStorage.setItem(LS_KEY, JSON.stringify(list));
+    try { localStorage.setItem(LS_KEY, JSON.stringify(list)); } catch {}
     this.store$.next(list);
   }
-
   private loadLS(): Course[] {
     try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]'); }
     catch { return []; }

--- a/src/assets/placeholder-course.svg
+++ b/src/assets/placeholder-course.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1D1E5B"/>
+      <stop offset="1" stop-color="#C54573"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" fill="url(#g)"/>
+  <g fill="#fff" opacity="0.9" font-family="Poppins, Arial, sans-serif">
+    <text x="50%" y="50%" text-anchor="middle" font-size="28">Rym May — Curso</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add course placeholder image
- revamp `CourseService` with localStorage persistence and placeholder handling
- notify user when course create/update succeeds

## Testing
- `npm install`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6886f26a77488332a9075c8337a8428d