### PR TITLE
Add blurred confirm dialog and brand snackbars

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -8,6 +8,7 @@ import { Course } from '../models/course.model';
 import { CourseService } from '../services/course.service';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { MatDialog } from '@angular/material/dialog';
+import { ConfirmDialogComponent } from '../dialogs/confirm-dialog/confirm-dialog.component';
 import { v4 as uuid } from 'uuid';
 import { CourseFormComponent } from '../dialogs/course-form/course-form.component';
 
@@ -64,6 +65,23 @@ export class CoursesComponent {
   }
 
   eliminar(id: string) {
-    this.courseSvc.remove(id);
+    this.dialog.open(ConfirmDialogComponent, {
+      data: { titulo: 'Confirmar', mensaje: '¿Eliminar este curso?' },
+      panelClass: 'rm-dialog',
+      backdropClass: 'rm-backdrop-blur',
+      width: '480px',
+      maxWidth: '95vw',
+      autoFocus: true
+    }).afterClosed().subscribe(ok => {
+      if (ok) {
+        this.courseSvc.remove(id);
+        this.snack.open('Curso eliminado', '', {
+          duration: 1800,
+          panelClass: 'snack-warn',
+          horizontalPosition: 'end',
+          verticalPosition: 'bottom'
+        });
+      }
+    });
   }
 }

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -54,7 +54,7 @@ export class StudentsComponent {
   constructor(
     private fb: FormBuilder,
     private studentSvc: StudentService,
-    private sb: MatSnackBar,
+    private snack: MatSnackBar,
     private dialog: MatDialog,
     private bp: BreakpointObserver
   ) {}
@@ -74,7 +74,7 @@ export class StudentsComponent {
       createdAt: Date.now()
     };
     this.studentSvc.add(student);
-    this.sb.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-fixed' });
+    this.snack.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-fixed' });
     this.form.reset();
   }
 
@@ -92,9 +92,22 @@ export class StudentsComponent {
 
   eliminar(row: Student) {
     this.dialog.open(ConfirmDialogComponent, {
-      data: { mensaje: '¿Eliminar este registro?' }
+      data: { titulo: 'Confirmar', mensaje: '¿Eliminar este registro?' },
+      panelClass: 'rm-dialog',
+      backdropClass: 'rm-backdrop-blur',
+      width: '480px',
+      maxWidth: '95vw',
+      autoFocus: true
     }).afterClosed().subscribe(ok => {
-      if (ok) this.studentSvc.remove(row.id);
+      if (ok) {
+        this.studentSvc.remove(row.id);
+        this.snack.open('Alumna eliminada', '', {
+          duration: 1800,
+          panelClass: 'snack-warn',
+          horizontalPosition: 'end',
+          verticalPosition: 'bottom'
+        });
+      }
     });
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,4 +12,28 @@
 
 /* Global resets */
 html, body { height: 100%; }
-body       { margin: 0; font-family: 'Poppins', Roboto, sans-serif; }
+body { margin: 0; font-family: 'Poppins', Roboto, sans-serif; }
+
+/* ---- Dialog backdrop blur ---- */
+.cdk-overlay-backdrop.rm-backdrop-blur {
+  /* grey, slightly darkened scrim + blur */
+  background: rgba(29, 30, 91, 0.25) !important;  /* brand blue tint */
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+/* ---- Brand snackbars (MDC) ---- */
+.mat-mdc-snack-bar-container.snack-success .mdc-snackbar__surface {
+  background: #1D1E5B;  /* primary */
+  color: #fff;
+}
+.mat-mdc-snack-bar-container.snack-warn .mdc-snackbar__surface {
+  background: #C54573;  /* accent for destructive/alert */
+  color: #fff;
+}
+/* optional: rounded shape & slight elevation */
+.mat-mdc-snack-bar-container.snack-success .mdc-snackbar__surface,
+.mat-mdc-snack-bar-container.snack-warn .mdc-snackbar__surface {
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.24);
+}


### PR DESCRIPTION
## Summary
- add reusable backdrop blur and brand snackbar styles
- enhance delete flow for courses and students

## Testing
- `npx ng test --watch=false` *(fails: ChromeHeadless cannot start)*

------
https://chatgpt.com/codex/tasks/task_e_6887de1521b88332b6a9262f0758b4ff