### PR TITLE
Fix dialog scrollbars and sizing

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -33,9 +33,11 @@ export class CoursesComponent {
   nuevo() {
     this.dialog.open(CourseFormComponent, {
       data: null,
-      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
-      width: '720px',
+      panelClass: 'rm-dialog',
+      backdropClass: 'rm-backdrop-blur',
+      width: 'min(720px, 95vw)',   // cap width to viewport
       maxWidth: '95vw',
+      maxHeight: '88vh',           // let content scroll inside
       autoFocus: true
     })
       .afterClosed()
@@ -50,9 +52,11 @@ export class CoursesComponent {
   editar(c: Course) {
     this.dialog.open(CourseFormComponent, {
       data: c,
-      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
-      width: '720px',
+      panelClass: 'rm-dialog',
+      backdropClass: 'rm-backdrop-blur',
+      width: 'min(720px, 95vw)',   // cap width to viewport
       maxWidth: '95vw',
+      maxHeight: '88vh',           // let content scroll inside
       autoFocus: true
     })
       .afterClosed()
@@ -69,8 +73,9 @@ export class CoursesComponent {
       data: { titulo: 'Confirmar', mensaje: '¿Eliminar este curso?' },
       panelClass: 'rm-dialog',
       backdropClass: 'rm-backdrop-blur',
-      width: '480px',
+      width: 'min(720px, 95vw)',
       maxWidth: '95vw',
+      maxHeight: '88vh',
       autoFocus: true
     }).afterClosed().subscribe(ok => {
       if (ok) {

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -81,9 +81,11 @@ export class StudentsComponent {
   editar(row: Student) {
     this.dialog.open(StudentEditDialogComponent, {
       data: { ...row },
-      panelClass: 'rm-dialog',      // ← apply brand dialog spacing
-      width: '720px',
+      panelClass: 'rm-dialog',
+      backdropClass: 'rm-backdrop-blur',
+      width: 'min(720px, 95vw)',   // cap width to viewport
       maxWidth: '95vw',
+      maxHeight: '88vh',           // let content scroll inside
       autoFocus: true
     }).afterClosed().subscribe(result => {
       if (result) this.studentSvc.edit(result as Student);
@@ -95,8 +97,9 @@ export class StudentsComponent {
       data: { titulo: 'Confirmar', mensaje: '¿Eliminar este registro?' },
       panelClass: 'rm-dialog',
       backdropClass: 'rm-backdrop-blur',
-      width: '480px',
+      width: 'min(720px, 95vw)',
       maxWidth: '95vw',
+      maxHeight: '88vh',
       autoFocus: true
     }).afterClosed().subscribe(ok => {
       if (ok) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -37,3 +37,6 @@ body { margin: 0; font-family: 'Poppins', Roboto, sans-serif; }
   border-radius: 12px;
   box-shadow: 0 8px 24px rgba(0,0,0,.24);
 }
+
+/* Global safety net to avoid stray horizontal scrollbars */
+html, body { overflow-x: hidden; }

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -18,8 +18,10 @@
     display: block;
     /* Extra top padding prevents outline labels from clipping under the title */
     padding: layout.$space-3 layout.$space-2 layout.$space-2;
-    max-height: min(72vh, 72dvh);
-    overflow: auto;
+    max-height: min(78vh, 78dvh);   /* a bit taller than before */
+    overflow: auto;                 /* scroll only here */
+    overflow-x: hidden;             /* never side-scroll */
+    box-sizing: border-box;
     scrollbar-gutter: stable both-edges;
   }
 
@@ -35,13 +37,14 @@
     position: sticky;
     bottom: 0;
     background: #fff;
-    padding: layout.$space-2;
-    margin: 0 -24px -8px;
+    padding: layout.$space-2;       /* no negative margins */
+    margin: 0;                      /* ← important: prevents horizontal overflow */
     border-top: 1px solid rgba(0,0,0,.06);
     z-index: 1;
+    box-sizing: border-box;
   }
 
   /* Field rhythm */
-  .mat-mdc-form-field { width: 100%; }
+  .mat-mdc-form-field { width: 100%; min-width: 0; }
   .mat-mdc-form-field + .mat-mdc-form-field { margin-top: layout.$space-2; }
 }


### PR DESCRIPTION
## Summary
- improve dialog styles to avoid horizontal overflow
- limit dialog width and height when opening Course/Student forms and confirms
- prevent global body horizontal scrolling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ec8c89e8833280b6543efa8b4656