### PR TITLE
Implement dashboard charts and KPIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "uuid": "^11.1.0",
-    "zone.js": "~0.14.3"
+    "zone.js": "~0.14.3",
+    "echarts": "^5.5.0",
+    "ngx-echarts": "17.2.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.2",

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,52 @@
-<h2>Panel</h2>
-<button mat-raised-button color="accent">
-  Botón destacado
-</button>
+<section class="dashboard">
+  <!-- KPI cards -->
+  <div class="kpis" *ngIf="(students | async) as st && (courses | async) as cs">
+    <mat-card class="kpi">
+      <mat-icon>group</mat-icon>
+      <div class="val">{{ st.length }}</div>
+      <div class="lbl">Alumnas registradas</div>
+    </mat-card>
+
+    <mat-card class="kpi">
+      <mat-icon>verified</mat-icon>
+      <div class="val">{{ st.filter(s => s.paidDeposit).length }}</div>
+      <div class="lbl">Depósitos pagados</div>
+    </mat-card>
+
+    <mat-card class="kpi">
+      <mat-icon>school</mat-icon>
+      <div class="val">{{ cs.length }}</div>
+      <div class="lbl">Cursos activos</div>
+    </mat-card>
+
+    <mat-card class="kpi">
+      <mat-icon>event</mat-icon>
+      <div class="val">
+        {{
+          st.filter(s => new Date(s.createdAt) >= (d=>{d.setDate(d.getDate()-30);return d;})(new Date())).length
+        }}
+      </div>
+      <div class="lbl">Nuevas (30 días)</div>
+    </mat-card>
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <!-- Charts -->
+  <div class="charts" *ngIf="(students | async) as st && (courses | async) as cs">
+    <mat-card class="chart">
+      <h3>Alumnas por curso</h3>
+      <div echarts [options]="buildCharts(st, cs).bar" class="echart"></div>
+    </mat-card>
+
+    <mat-card class="chart">
+      <h3>Inscripciones por semana</h3>
+      <div echarts [options]="buildCharts(st, cs).line" class="echart"></div>
+    </mat-card>
+
+    <mat-card class="chart">
+      <h3>Depósitos</h3>
+      <div echarts [options]="buildCharts(st, cs).pie" class="echart"></div>
+    </mat-card>
+  </div>
+</section>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,0 +1,42 @@
+@use '../../styles/layout';
+
+.dashboard {
+  display: grid;
+  gap: layout.$space-3;
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: layout.$space-2;
+
+  @media (max-width: 959px){ grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 599px){ grid-template-columns: 1fr; }
+}
+
+.kpi {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: layout.$space-1;
+  padding: layout.$space-2;
+
+  .mat-icon { grid-row: span 2; font-size: 28px; color: #1D1E5B; }
+  .val      { font: 700 clamp(1.25rem, 1.2vw + 1rem, 1.8rem) 'Barlow Semi Condensed', sans-serif; color: #1D1E5B; }
+  .lbl      { font: 400 0.95rem 'Poppins', sans-serif; color: #4a4b57; }
+}
+
+.charts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: layout.$space-2;
+  @media (max-width: 1199px){ grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 767px){ grid-template-columns: 1fr; }
+}
+
+.chart {
+  padding: layout.$space-2;
+  h3 { margin: 0 0 layout.$space-1; font: 700 1.05rem 'Poppins', sans-serif; color: #1D1E5B; }
+  .echart { width: 100%; height: 280px; }
+}

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,15 @@
-import { Component } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
+import { Component, computed, inject, signal } from '@angular/core';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { StudentService } from '../services/student.service';
+import { CourseService } from '../services/course.service';
+import { precioToNumber, startOfWeek, weeksBack } from '../utils/metrics';
+
+// ngx-echarts standalone directive
+import { NgxEchartsDirective } from 'ngx-echarts';
+import type { EChartsOption } from 'echarts';
 
 @Component({
   selector: 'app-dashboard',
@@ -7,7 +17,78 @@ import { MatButtonModule } from '@angular/material/button';
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
   imports: [
-    MatButtonModule      
+    AsyncPipe, NgFor, NgIf,
+    MatCardModule, MatIconModule, MatDividerModule,
+    NgxEchartsDirective
   ]
 })
-export class DashboardComponent {}
+export class DashboardComponent {
+  private studentsSvc = inject(StudentService);
+  private coursesSvc  = inject(CourseService);
+
+  // Snapshot data (services expose BehaviorSubjects)
+  students = this.studentsSvc.students$;
+  courses  = this.coursesSvc.courses$;
+
+  // Derived KPIs (computed inside template with | async in a minimal way)
+  // We’ll also compute chart options when async data arrives (in template via (echartsInit)? not required; we use getters)
+
+  // Build chart options from arrays
+  buildCharts(students: any[], courses: any[]): {bar:EChartsOption, line:EChartsOption, pie:EChartsOption} {
+    // 1) Alumnas por curso (bar)
+    const byCourseMap = new Map<string, number>();
+    courses.forEach(c => byCourseMap.set(c.id, 0));
+    students.forEach(s => byCourseMap.set(s.courseId, (byCourseMap.get(s.courseId) || 0) + 1));
+    const barCats = courses.map(c => c.nombre);
+    const barData = courses.map(c => byCourseMap.get(c.id) || 0);
+
+    const brandBlue = '#1D1E5B', accent = '#C54573', gold = '#F0C94A', grey = '#DCDDE0';
+
+    const bar: EChartsOption = {
+      grid: { left: 40, right: 16, top: 24, bottom: 40 },
+      tooltip: { trigger: 'axis' },
+      xAxis: { type: 'category', data: barCats, axisLabel: { rotate: 15 } },
+      yAxis: { type: 'value' },
+      series: [{ type: 'bar', data: barData, itemStyle: { color: brandBlue }, barWidth: '50%' }]
+    };
+
+    // 2) Inscripciones por semana (últimas 8)
+    const weeks = weeksBack(8);
+    const countByWeek = weeks.map(w => 0);
+    students.forEach(s => {
+      const w = startOfWeek(s.createdAt);
+      const idx = weeks.indexOf(w);
+      if (idx >= 0) countByWeek[idx]++;
+    });
+    const weekLabels = weeks.map(w => {
+      const d = new Date(w);
+      return `${d.getDate()}/${d.getMonth()+1}`;
+    });
+    const line: EChartsOption = {
+      grid: { left: 40, right: 16, top: 24, bottom: 40 },
+      tooltip: { trigger: 'axis' },
+      xAxis: { type: 'category', data: weekLabels },
+      yAxis: { type: 'value' },
+      series: [{ type: 'line', smooth: true, data: countByWeek, areaStyle: { opacity: 0.1 }, lineStyle: { color: accent }, itemStyle: { color: accent } }]
+    };
+
+    // 3) Depósitos (pie)
+    const paid = students.filter(s => s.paidDeposit).length;
+    const unpaid = students.length - paid;
+    const pie: EChartsOption = {
+      tooltip: { trigger: 'item' },
+      series: [{
+        type: 'pie',
+        radius: ['45%','70%'],
+        avoidLabelOverlap: true,
+        label: { formatter: '{b}: {c}', color: brandBlue },
+        data: [
+          { name: 'Pagado', value: paid, itemStyle: { color: accent }},
+          { name: 'Pendiente', value: unpaid, itemStyle: { color: grey } }
+        ]
+      }]
+    };
+
+    return { bar, line, pie };
+  }
+}

--- a/src/app/utils/metrics.ts
+++ b/src/app/utils/metrics.ts
@@ -1,0 +1,23 @@
+export function precioToNumber(precio: string): number {
+  // "MX$ 3\u202f500" or "MXS 4 200" → 3500 / 4200
+  const digits = (precio || '').replace(/[^\d]/g, '');
+  return digits ? Number(digits) : 0;
+}
+
+export function startOfWeek(ts: number): number {
+  const d = new Date(ts);
+  const day = d.getDay(); // 0..6 (Sun..Sat)
+  const diff = (day + 6) % 7; // make Monday=0
+  d.setHours(0,0,0,0);
+  d.setDate(d.getDate() - diff);
+  return d.getTime();
+}
+
+export function weeksBack(n: number): number[] {
+  const out: number[] = [];
+  const now = new Date();
+  now.setHours(0,0,0,0);
+  const base = startOfWeek(now.getTime());
+  for (let i = n-1; i >= 0; i--) out.push(base - i * 7 * 24 * 3600 * 1000);
+  return out;
+}


### PR DESCRIPTION
## Summary
- add echarts and ngx-echarts deps
- provide metric utilities for weekly grouping
- implement dashboard with KPI counters and three charts
- style dashboard responsively

## Testing
- `npm test -- --watch=false` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6887f984ca3c833296cbed5b3a77be15