### PR TITLE
Fix ngx-echarts provider and allow multiple courses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "@angular/platform-server": "^17.3.0",
         "@angular/router": "^17.3.0",
         "@angular/ssr": "^17.3.2",
+        "echarts": "^5.5.0",
         "express": "^4.18.2",
+        "ngx-echarts": "^20.0.1",
         "pdfjs-dist": "^5.3.93",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -6684,6 +6686,22 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9637,6 +9655,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/ngx-echarts": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-echarts/-/ngx-echarts-20.0.1.tgz",
+      "integrity": "sha512-SpMj8jX4qVle1ZEA3ob4AlTXduhsUeMQdyILu7UWcNr/zRqR3dPgiiahIepdOIel+5PJDl3qtJGUiYhuIyUUMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=20.0.0",
+        "echarts": ">=5.0.0"
       }
     },
     "node_modules/nice-napi": {
@@ -13848,6 +13879,21 @@
       "version": "0.14.10",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
       "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ=="
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "uuid": "^11.1.0",
     "zone.js": "~0.14.3",
     "echarts": "^5.5.0",
-    "ngx-echarts": "17.2.0"
+    "ngx-echarts": "^20.0.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.2",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,17 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideEchartsCore } from 'ngx-echarts';
+import * as echarts from 'echarts';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideClientHydration(), provideAnimationsAsync()]
+  providers: [
+    provideRouter(routes),
+    provideClientHydration(),
+    provideAnimationsAsync(),
+    provideEchartsCore({ echarts }),
+  ]
 };

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -53,7 +53,9 @@ export class DashboardComponent {
     // 1) Alumnas por curso (bar)
     const byCourseMap = new Map<string, number>();
     courses.forEach(c => byCourseMap.set(c.id, 0));
-    students.forEach(s => byCourseMap.set(s.courseId, (byCourseMap.get(s.courseId) || 0) + 1));
+    students.forEach(s => s.courseIds.forEach(id =>
+      byCourseMap.set(id, (byCourseMap.get(id) || 0) + 1)
+    ));
     const barCats = courses.map(c => c.nombre);
     const barData = courses.map(c => byCourseMap.get(c.id) || 0);
 

--- a/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.html
+++ b/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.html
@@ -22,9 +22,17 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline" color="accent">
-      <mat-label>ID del curso</mat-label>
-      <input matInput formControlName="courseId" />
-      <mat-error *ngIf="form.controls.courseId.hasError('required')">Requerido</mat-error>
+      <mat-label>Curso(s)</mat-label>
+      <mat-select formControlName="courseIds" multiple>
+        <mat-select-trigger>
+          {{ (form.value.courseIds?.length || 0) }} seleccionado(s)
+        </mat-select-trigger>
+        <mat-option *ngFor="let c of (courses$ | async) || []" [value]="c.id">
+          {{ c.nombre }}
+        </mat-option>
+      </mat-select>
+      <mat-hint>Puede seleccionar uno o varios cursos</mat-hint>
+      <mat-error *ngIf="form.controls.courseIds.hasError('required')">Requerido</mat-error>
     </mat-form-field>
 
     <mat-checkbox formControlName="paidDeposit" class="full-row">Depósito pagado</mat-checkbox>

--- a/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.ts
+++ b/src/app/dialogs/student-edit-dialog/student-edit-dialog.component.ts
@@ -6,6 +6,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { CourseService } from '../../services/course.service';
 
 @Component({
   standalone: true,
@@ -17,22 +19,25 @@ import { MatButtonModule } from '@angular/material/button';
     MatInputModule,
     MatCheckboxModule,
     MatButtonModule,
+    MatSelectModule,
   ],
   templateUrl: './student-edit-dialog.component.html',
   styleUrls: ['./student-edit-dialog.component.scss']
 })
 export class StudentEditDialogComponent {
+  courses$ = this.courseSvc.courses$;
   form = this.fb.group({
     fullName: [this.data?.fullName ?? '', [Validators.required, Validators.minLength(3)]],
     phone:    [this.data?.phone ?? '', [Validators.required]],
     email:    [this.data?.email ?? '', [Validators.email]],
-    courseId: [this.data?.courseId ?? '', [Validators.required]],
+    courseIds: [this.data?.courseIds ?? [], [Validators.required]],
     paidDeposit: [!!this.data?.paidDeposit]
   });
   constructor(
     private fb: FormBuilder,
     private ref: MatDialogRef<StudentEditDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private courseSvc: CourseService
   ) {}
   guardar(){ if (this.form.valid) this.ref.close({ ...this.data, ...this.form.value }); }
 }

--- a/src/app/models/student.model.ts
+++ b/src/app/models/student.model.ts
@@ -3,7 +3,7 @@ export interface Student {
   fullName: string;
   phone: string;
   email: string;
-  courseId: string;
+  courseIds: string[];
   paidDeposit: boolean;
   createdAt: number;       // epoch
 }

--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -16,9 +16,17 @@
     <input matInput formControlName="email" />
   </mat-form-field>
 
-  <mat-form-field appearance="outline">
-    <mat-label>ID del curso</mat-label>
-    <input matInput formControlName="courseId" placeholder="p.ej. LASH‑BASICS" />
+  <mat-form-field appearance="outline" class="col">
+    <mat-label>Curso(s)*</mat-label>
+    <mat-select formControlName="courseIds" multiple>
+      <mat-select-trigger>
+        {{ selectedCourseCount }} seleccionado(s)
+      </mat-select-trigger>
+      <mat-option *ngFor="let c of (courses$ | async) || []" [value]="c.id">
+        {{ c.nombre }}
+      </mat-option>
+    </mat-select>
+    <mat-hint>Puede seleccionar uno o varios cursos</mat-hint>
   </mat-form-field>
 
   <mat-checkbox formControlName="paidDeposit">Depósito pagado</mat-checkbox>
@@ -48,9 +56,11 @@
     <td mat-cell *matCellDef="let s">{{ s.email }}</td>
   </ng-container>
 
-  <ng-container matColumnDef="courseId">
-    <th mat-header-cell *matHeaderCellDef>Curso</th>
-    <td mat-cell *matCellDef="let s">{{ s.courseId }}</td>
+  <ng-container matColumnDef="courses">
+    <th mat-header-cell *matHeaderCellDef>Cursos</th>
+    <td mat-cell *matCellDef="let s">
+      {{ (coursesMap | async)?.mapIds(s.courseIds)?.join(', ') }}
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="paidDeposit">

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -3,7 +3,9 @@ import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { v4 as uuid } from 'uuid';
 
 import { StudentService } from '../services/student.service';
+import { CourseService } from '../services/course.service';
 import { Student } from '../models/student.model';
+import { map } from 'rxjs';
 
 /* Material */
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -14,6 +16,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSelectModule } from '@angular/material/select';
 import { InvoiceDialogComponent } from '../invoice-dialog/invoice-dialog.component';
 import { StudentEditDialogComponent } from '../dialogs/student-edit-dialog/student-edit-dialog.component';
 import { ConfirmDialogComponent } from '../dialogs/confirm-dialog/confirm-dialog.component';
@@ -28,32 +31,50 @@ import { AsyncPipe } from '@angular/common';
     MatFormFieldModule, MatInputModule,
     MatCheckboxModule, MatButtonModule,
     MatTableModule, MatSnackBarModule,
-    MatIconModule, MatDialogModule
+    MatIconModule, MatDialogModule,
+    MatSelectModule
   ],
   templateUrl: './students.component.html',
   styleUrls: ['./students.component.scss']
 })
 export class StudentsComponent {
 
-  displayedColumnsHandset = ['fullName','courseId','factura','acciones'] as const;
-  displayedColumnsDesktop = ['fullName','phone','email','courseId','paidDeposit','factura','acciones'] as const;
+  displayedColumnsHandset = ['fullName','courses','factura','acciones'] as const;
+  displayedColumnsDesktop = ['fullName','phone','email','courses','paidDeposit','factura','acciones'] as const;
   displayedColumns = this.bp.isMatched(Breakpoints.Handset)
     ? this.displayedColumnsHandset : this.displayedColumnsDesktop;
 
 
   students$ = this.studentSvc.students$;
+  courses$  = this.courseSvc.courses$;
+
+  coursesMap = this.courseSvc.courses$.pipe(
+    map(list => {
+      const map = new Map(list.map(c => [c.id, c.nombre]));
+      return {
+        map,
+        mapIds: (ids: string[]) => ids.map(id => map.get(id) ?? id)
+      };
+    })
+  );
 
   form = this.fb.group({
     fullName: ['', [Validators.required, Validators.minLength(3)]],
     phone:    ['', Validators.required],
     email:    ['', [Validators.email]],
-    courseId: ['', Validators.required],
+    courseIds: [[], Validators.required],
     paidDeposit: [false]
   });
+
+  get selectedCourseCount(): number {
+    const val = this.form.get('courseIds')?.value;
+    return Array.isArray(val) ? (val as any[]).length : 0;
+  }
 
   constructor(
     private fb: FormBuilder,
     private studentSvc: StudentService,
+    private courseSvc: CourseService,
     private snack: MatSnackBar,
     private dialog: MatDialog,
     private bp: BreakpointObserver
@@ -75,7 +96,7 @@ export class StudentsComponent {
     };
     this.studentSvc.add(student);
     this.snack.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-fixed' });
-    this.form.reset();
+    this.form.reset({ courseIds: [] as any });
   }
 
   editar(row: Student) {


### PR DESCRIPTION
## Summary
- register ECharts globally using `provideEchartsCore`
- support multiple courses on the student model and form
- update edit dialog to match multi‑select UI
- adjust dashboard to handle `courseIds`

## Testing
- `npm install --legacy-peer-deps`
- `npm run build --silent` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688866a603ac8332aa47c1bbaca27ef1