### PR TITLE
Disable SSR for GH Pages static deploy

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,10 +39,8 @@
             ],
             "scripts": [],
             "server": "src/main.server.ts",
-            "prerender": true,
-            "ssr": {
-              "entry": "server.ts"
-            }
+            "prerender": false,
+            "ssr": false
           },
           "configurations": {
             "production": {
@@ -63,7 +61,9 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "prerender": false,
+              "ssr": false
             }
           },
           "defaultConfiguration": "production"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --no-ssr -o",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:rym-may": "node dist/rym-may/server/server.mjs"
+    "serve:ssr:rym-may": "node dist/rym-may/server/server.mjs",
+    "build:pages": "ng build --output-path docs --base-href /rym-may/",
+    "postbuild:pages": "cp docs/index.html docs/404.html"
   },
   "private": true,
   "dependencies": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,6 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideEchartsCore } from 'ngx-echarts';
-import * as echarts from 'echarts';
+import { provideEcharts } from 'ngx-echarts';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
@@ -12,6 +11,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideClientHydration(),
     provideAnimationsAsync(),
-    provideEchartsCore({ echarts }),
+    provideEcharts(),
   ]
 };

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -34,17 +34,17 @@
       <div class="charts">
         <mat-card class="chart">
           <h3>Alumnas por curso</h3>
-          <div echarts [options]="buildCharts(st, cs).bar" class="echart"></div>
+          <div echarts [options]="vm.charts.bar" class="echart"></div>
         </mat-card>
 
         <mat-card class="chart">
           <h3>Inscripciones por semana</h3>
-          <div echarts [options]="buildCharts(st, cs).line" class="echart"></div>
+          <div echarts [options]="vm.charts.line" class="echart"></div>
         </mat-card>
 
         <mat-card class="chart">
           <h3>Depósitos</h3>
-          <div echarts [options]="buildCharts(st, cs).pie" class="echart"></div>
+          <div echarts [options]="vm.charts.pie" class="echart"></div>
         </mat-card>
       </div>
 

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -40,3 +40,5 @@
   h3 { margin: 0 0 layout.$space-1; font: 700 1.05rem 'Poppins', sans-serif; color: #1D1E5B; }
   .echart { width: 100%; height: 280px; }
 }
+
+.echart { width: 100%; height: 280px; }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { combineLatest } from 'rxjs';
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -27,6 +28,14 @@ import type { EChartsOption } from 'echarts';
 export class DashboardComponent {
   private studentsSvc = inject(StudentService);
   private coursesSvc  = inject(CourseService);
+
+  vm = { charts: { bar: {} as EChartsOption, line: {} as EChartsOption, pie: {} as EChartsOption } };
+
+  constructor() {
+    combineLatest([this.studentsSvc.students$, this.coursesSvc.courses$]).subscribe(([st, cs]) => {
+      this.vm.charts = this.buildCharts(st, cs);
+    });
+  }
 
   // Snapshot data (services expose BehaviorSubjects)
   students = this.studentsSvc.students$;


### PR DESCRIPTION
## Summary
- disable SSR and prerender in Angular workspace
- use provideEcharts for browser charts only
- expose computed chart options via `vm` and use them in templates
- style `.echart` divs with fixed height
- serve client-only during dev
- add GitHub Pages build scripts

## Testing
- `npm test` *(fails: ChromeHeadless missing shared libraries)*

------
https://chatgpt.com/codex/tasks/task_e_688899273b2483329333099262b64aa9