### PR TITLE
Fix empty state for cursos select

### DIFF
--- a/src/app/students/students.component.html
+++ b/src/app/students/students.component.html
@@ -1,4 +1,7 @@
-<h2 class="titulo-seccion">Registrar alumna</h2>
+<h2 class="titulo-seccion">
+  Registrar alumna
+  <a routerLink="/courses" class="mini-link">Crear curso</a>
+</h2>
 
 <form [formGroup]="form" class="student-form" (ngSubmit)="save()">
   <mat-form-field appearance="outline">
@@ -18,15 +21,25 @@
 
   <mat-form-field appearance="outline" class="col">
     <mat-label>Curso(s)*</mat-label>
-    <mat-select formControlName="courseIds" multiple>
+    <mat-select formControlName="courseIds" multiple aria-label="Seleccionar cursos">
       <mat-select-trigger>
         {{ selectedCourseCount }} seleccionado(s)
       </mat-select-trigger>
-      <mat-option *ngFor="let c of (courses$ | async) || []" [value]="c.id">
-        {{ c.nombre }}
-      </mat-option>
+
+      <!-- Empty state when no courses exist -->
+      <ng-container *ngIf="(courses$ | async) as cursos">
+        <mat-option *ngIf="!cursos.length" disabled>
+          No hay cursos disponibles — cree un curso primero
+        </mat-option>
+        <mat-option *ngFor="let c of cursos; trackBy: trackById" [value]="c.id">
+          {{ c.nombre }}
+        </mat-option>
+      </ng-container>
     </mat-select>
     <mat-hint>Puede seleccionar uno o varios cursos</mat-hint>
+    <mat-error *ngIf="form.controls.courseIds.hasError('required')">
+      Selecciona al menos un curso
+    </mat-error>
   </mat-form-field>
 
   <mat-checkbox formControlName="paidDeposit">Depósito pagado</mat-checkbox>

--- a/src/app/students/students.component.scss
+++ b/src/app/students/students.component.scss
@@ -17,3 +17,9 @@
 @container style(max-width: 480px) {
   .student-table { font-size: .85rem; }
 }
+
+.mini-link {
+  color: #C54573;
+  font-size: .9em;
+  margin-left: 0.5rem;
+}

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -17,22 +17,25 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatSelectModule } from '@angular/material/select';
+import { MatOptionModule } from '@angular/material/core';
 import { InvoiceDialogComponent } from '../invoice-dialog/invoice-dialog.component';
 import { StudentEditDialogComponent } from '../dialogs/student-edit-dialog/student-edit-dialog.component';
 import { ConfirmDialogComponent } from '../dialogs/confirm-dialog/confirm-dialog.component';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgIf, NgFor } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-students',
   standalone: true,
   imports: [
-    ReactiveFormsModule, AsyncPipe,
+    ReactiveFormsModule, AsyncPipe, NgIf, NgFor,
+    RouterModule,
     MatFormFieldModule, MatInputModule,
     MatCheckboxModule, MatButtonModule,
     MatTableModule, MatSnackBarModule,
     MatIconModule, MatDialogModule,
-    MatSelectModule
+    MatSelectModule, MatOptionModule
   ],
   templateUrl: './students.component.html',
   styleUrls: ['./students.component.scss']
@@ -70,6 +73,8 @@ export class StudentsComponent {
     const val = this.form.get('courseIds')?.value;
     return Array.isArray(val) ? (val as any[]).length : 0;
   }
+
+  trackById = (_: number, item: { id: string }) => item.id;
 
   constructor(
     private fb: FormBuilder,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,3 +40,6 @@ body { margin: 0; font-family: 'Poppins', Roboto, sans-serif; }
 
 /* Global safety net to avoid stray horizontal scrollbars */
 html, body { overflow-x: hidden; }
+
+/* Ensure Material overlays (mat-select panel, menus, dialogs) sit above toolbar/sidenav */
+.cdk-overlay-container { z-index: 2000; } /* higher than any local headers */


### PR DESCRIPTION
## Summary
- improve courses multi-select with disabled empty state option
- ensure overlay panel appears on top
- allow creating a course from students page
- include MatOptionModule and common pipes

## Testing
- `npm ci --legacy-peer-deps`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_688957768b948332bc3b196e06a63224