### PR TITLE
Add hover & focus styles to dashboard cards

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,25 +1,25 @@
 <ng-container *ngIf="vm$ | async as vm">
   <!-- KPIs -->
   <section class="kpis">
-    <article class="kpi">
+    <article class="kpi" tabindex="0">
       <div class="icon">👩‍🎓</div>
       <div class="val">{{ vm.students.length }}</div>
       <div class="label">Alumnas registradas</div>
     </article>
 
-    <article class="kpi">
+    <article class="kpi" tabindex="0">
       <div class="icon">✅</div>
       <div class="val">{{ depositsPaid(vm.students) }}</div>
       <div class="label">Depósitos pagados</div>
     </article>
 
-    <article class="kpi">
+    <article class="kpi" tabindex="0">
       <div class="icon">📅</div>
       <div class="val">{{ enrollmentsLast30Days(vm.students) }}</div>
       <div class="label">Inscripciones (30 días)</div>
     </article>
 
-    <article class="kpi">
+    <article class="kpi" tabindex="0">
       <div class="icon">🎓</div>
       <div class="val">{{ vm.courses.length }}</div>
       <div class="label">Cursos publicados</div>
@@ -28,8 +28,14 @@
 
   <!-- Charts -->
   <section class="charts">
-    <div echarts [options]="buildCharts(vm.students, vm.courses).bar"  class="echart"></div>
-    <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
-    <div echarts [options]="buildCharts(vm.students, vm.courses).pie"  class="echart"></div>
+    <div class="chart-card" tabindex="0" aria-label="Gráfica de alumnas por curso">
+      <div echarts [options]="buildCharts(vm.students, vm.courses).bar" class="echart"></div>
+    </div>
+    <div class="chart-card" tabindex="0" aria-label="Inscripciones por semana">
+      <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
+    </div>
+    <div class="chart-card" tabindex="0" aria-label="Distribución de depósitos">
+      <div echarts [options]="buildCharts(vm.students, vm.courses).pie" class="echart"></div>
+    </div>
   </section>
 </ng-container>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -37,3 +37,58 @@
 @media (max-width: 1100px) {
   .charts { grid-template-columns: 1fr; }
 }
+
+/* ---------- Hover & focus motion for KPI and chart cards ---------- */
+
+/* Shared surface/elevation tokens */
+:root {
+  --rm-elev0: 0 1px 2px rgba(0,0,0,.06);
+  --rm-elev1: 0 4px 12px rgba(0,0,0,.10);
+  --rm-scale: 1.01;
+}
+
+/* Make cards feel tangible without implying click-through */
+.kpis .kpi,
+.charts .chart-card,
+.mat-mdc-card.panel {
+  will-change: transform, box-shadow;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 120ms ease,
+    border-color 120ms ease;
+  box-shadow: var(--rm-elev0);
+  border-radius: 14px; /* a bit softer corners */
+  background: #fff;
+}
+
+/* Hover: subtle lift + shadow; keep cursor default (not a button) */
+.kpis .kpi:hover,
+.charts .chart-card:hover,
+.mat-mdc-card.panel:hover {
+  transform: translateY(-2px) scale(var(--rm-scale));
+  box-shadow: var(--rm-elev1);
+}
+
+/* Keyboard accessibility: visible focus ring using brand accent */
+.kpis .kpi:focus-visible,
+.charts .chart-card:focus-visible,
+.mat-mdc-card.panel:focus-visible {
+  outline: 3px solid #E14D82; /* Rym May accent */
+  outline-offset: 2px;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .kpis .kpi,
+  .charts .chart-card,
+  .mat-mdc-card.panel {
+    transition: none;
+    transform: none !important;
+  }
+}
+
+/* Optional: lighten icon pill slightly on hover for feedback */
+.kpis .kpi:hover .icon {
+  filter: brightness(1.03);
+}


### PR DESCRIPTION
## Summary
- allow keyboard focus on dashboard KPI and chart cards
- add hover elevation and focus ring styling

## Testing
- `npm test --silent -- --watch=false` *(fails: ChromeHeadless missing libatk)*

------
https://chatgpt.com/codex/tasks/task_e_6889a9b11398833287d559830d1e061c