### PR TITLE
Enhance dashboard panel hover states

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,41 +1,41 @@
 <ng-container *ngIf="vm$ | async as vm">
   <!-- KPIs -->
   <section class="kpis">
-    <article class="kpi" tabindex="0">
+    <div class="panel kpi" tabindex="0">
       <div class="icon">👩‍🎓</div>
       <div class="val">{{ vm.students.length }}</div>
       <div class="label">Alumnas registradas</div>
-    </article>
+    </div>
 
-    <article class="kpi" tabindex="0">
+    <div class="panel kpi" tabindex="0">
       <div class="icon">✅</div>
       <div class="val">{{ depositsPaid(vm.students) }}</div>
       <div class="label">Depósitos pagados</div>
-    </article>
+    </div>
 
-    <article class="kpi" tabindex="0">
+    <div class="panel kpi" tabindex="0">
       <div class="icon">📅</div>
       <div class="val">{{ enrollmentsLast30Days(vm.students) }}</div>
       <div class="label">Inscripciones (30 días)</div>
-    </article>
+    </div>
 
-    <article class="kpi" tabindex="0">
+    <div class="panel kpi" tabindex="0">
       <div class="icon">🎓</div>
       <div class="val">{{ vm.courses.length }}</div>
       <div class="label">Cursos publicados</div>
-    </article>
+    </div>
   </section>
 
   <!-- Charts -->
-  <section class="charts">
-    <div class="chart-card" tabindex="0" aria-label="Gráfica de alumnas por curso">
-      <div echarts [options]="buildCharts(vm.students, vm.courses).bar" class="echart"></div>
-    </div>
-    <div class="chart-card" tabindex="0" aria-label="Inscripciones por semana">
-      <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
-    </div>
-    <div class="chart-card" tabindex="0" aria-label="Distribución de depósitos">
-      <div echarts [options]="buildCharts(vm.students, vm.courses).pie" class="echart"></div>
-    </div>
+    <section class="charts">
+      <div class="panel chart-card" tabindex="0" aria-label="Gráfica de alumnas por curso">
+        <div echarts [options]="buildCharts(vm.students, vm.courses).bar" class="echart"></div>
+      </div>
+      <div class="panel chart-card" tabindex="0" aria-label="Inscripciones por semana">
+        <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
+      </div>
+      <div class="panel chart-card" tabindex="0" aria-label="Distribución de depósitos">
+        <div echarts [options]="buildCharts(vm.students, vm.courses).pie" class="echart"></div>
+      </div>
   </section>
 </ng-container>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -10,12 +10,6 @@
   margin-bottom: 24px;
 }
 
-.kpi {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 10px rgba(0,0,0,.06);
-  padding: 16px 18px;
-}
 
 .kpi .val   { font: 600 28px/1 'Poppins', system-ui; color: #1D1E5B; }
 .kpi .label { color: #6b7280; font-size: 14px; }
@@ -38,57 +32,71 @@
   .charts { grid-template-columns: 1fr; }
 }
 
-/* ---------- Hover & focus motion for KPI and chart cards ---------- */
 
-/* Shared surface/elevation tokens */
-:root {
-  --rm-elev0: 0 1px 2px rgba(0,0,0,.06);
-  --rm-elev1: 0 4px 12px rgba(0,0,0,.10);
-  --rm-scale: 1.01;
-}
-
-/* Make cards feel tangible without implying click-through */
-.kpis .kpi,
-.charts .chart-card,
-.mat-mdc-card.panel {
-  will-change: transform, box-shadow;
-  transition:
-    transform 180ms ease,
-    box-shadow 180ms ease,
-    background-color 120ms ease,
-    border-color 120ms ease;
-  box-shadow: var(--rm-elev0);
-  border-radius: 14px; /* a bit softer corners */
+/* Dashboard panels (KPIs & charts) */
+.panel {
+  position: relative;
   background: #fff;
-}
+  border-radius: 16px;
+  box-shadow: 0 2px 10px rgba(0,0,0,.06);
+  transition:
+    transform 180ms cubic-bezier(.2,.0,.2,1),
+    box-shadow 180ms cubic-bezier(.2,.0,.2,1),
+    filter 180ms cubic-bezier(.2,.0,.2,1);
+  will-change: transform;
 
-/* Hover: subtle lift + shadow; keep cursor default (not a button) */
-.kpis .kpi:hover,
-.charts .chart-card:hover,
-.mat-mdc-card.panel:hover {
-  transform: translateY(-2px) scale(var(--rm-scale));
-  box-shadow: var(--rm-elev1);
-}
+  /* State layer (Material 3-esque) */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: rgba(197, 69, 115, 0.06); /* Rym May pink @ ~6% */
+    opacity: 0;
+    transition: opacity 180ms cubic-bezier(.2,.0,.2,1);
+    pointer-events: none;
+  }
 
-/* Keyboard accessibility: visible focus ring using brand accent */
-.kpis .kpi:focus-visible,
-.charts .chart-card:focus-visible,
-.mat-mdc-card.panel:focus-visible {
-  outline: 3px solid #E14D82; /* Rym May accent */
-  outline-offset: 2px;
-}
+  &:hover::after,
+  &:focus-within::after {
+    opacity: 1;
+  }
 
-/* Respect users who prefer reduced motion */
-@media (prefers-reduced-motion: reduce) {
-  .kpis .kpi,
-  .charts .chart-card,
-  .mat-mdc-card.panel {
-    transition: none;
-    transform: none !important;
+  &:hover,
+  &:focus-within {
+    transform: translateY(-6px) scale(1.01);
+    box-shadow: 0 10px 24px rgba(29, 30, 91, 0.18); /* brand blue shadow tint */
   }
 }
 
-/* Optional: lighten icon pill slightly on hover for feedback */
-.kpis .kpi:hover .icon {
-  filter: brightness(1.03);
+/* Reduce motion or touch devices – don’t animate hover */
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
+  .panel:hover,
+  .panel:focus-within {
+    transform: none;
+    box-shadow: 0 2px 10px rgba(0,0,0,.06);
+  }
+}
+@media (hover: none) {
+  .panel:hover {
+    transform: none;
+    box-shadow: 0 2px 10px rgba(0,0,0,.06);
+  }
+}
+
+/* Keep existing layout; only ensure KPI content doesn’t shift on hover */
+.kpi {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+  min-height: 96px; /* prevents vertical jiggle */
+}
+
+.chart-card {
+  padding: 16px 18px 6px;
 }


### PR DESCRIPTION
## Summary
- add `.panel` elements for KPIs and charts so cards gain focusable hover states
- implement animated elevation and state layer styles

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6889b4aa684c833293cad43b0e9c0dd5