### PR TITLE
Fix dashboard hover layering

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,25 +1,25 @@
 <ng-container *ngIf="vm$ | async as vm">
   <!-- KPIs -->
   <section class="kpis">
-    <div class="panel kpi" tabindex="0">
+    <div class="kpi-card" tabindex="0">
       <div class="icon">👩‍🎓</div>
       <div class="val">{{ vm.students.length }}</div>
       <div class="label">Alumnas registradas</div>
     </div>
 
-    <div class="panel kpi" tabindex="0">
+    <div class="kpi-card" tabindex="0">
       <div class="icon">✅</div>
       <div class="val">{{ depositsPaid(vm.students) }}</div>
       <div class="label">Depósitos pagados</div>
     </div>
 
-    <div class="panel kpi" tabindex="0">
+    <div class="kpi-card" tabindex="0">
       <div class="icon">📅</div>
       <div class="val">{{ enrollmentsLast30Days(vm.students) }}</div>
       <div class="label">Inscripciones (30 días)</div>
     </div>
 
-    <div class="panel kpi" tabindex="0">
+    <div class="kpi-card" tabindex="0">
       <div class="icon">🎓</div>
       <div class="val">{{ vm.courses.length }}</div>
       <div class="label">Cursos publicados</div>
@@ -28,14 +28,20 @@
 
   <!-- Charts -->
     <section class="charts">
-      <div class="panel chart-card" tabindex="0" aria-label="Gráfica de alumnas por curso">
-        <div echarts [options]="buildCharts(vm.students, vm.courses).bar" class="echart"></div>
+      <div class="chart-card" tabindex="0" aria-label="Gráfica de alumnas por curso">
+        <div class="chart-surface">
+          <div echarts [options]="buildCharts(vm.students, vm.courses).bar" class="echart"></div>
+        </div>
       </div>
-      <div class="panel chart-card" tabindex="0" aria-label="Inscripciones por semana">
-        <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
+      <div class="chart-card" tabindex="0" aria-label="Inscripciones por semana">
+        <div class="chart-surface">
+          <div echarts [options]="buildCharts(vm.students, vm.courses).line" class="echart"></div>
+        </div>
       </div>
-      <div class="panel chart-card" tabindex="0" aria-label="Distribución de depósitos">
-        <div echarts [options]="buildCharts(vm.students, vm.courses).pie" class="echart"></div>
+      <div class="chart-card" tabindex="0" aria-label="Distribución de depósitos">
+        <div class="chart-surface">
+          <div echarts [options]="buildCharts(vm.students, vm.courses).pie" class="echart"></div>
+        </div>
       </div>
   </section>
 </ng-container>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -11,8 +11,8 @@
 }
 
 
-.kpi .val   { font: 600 28px/1 'Poppins', system-ui; color: #1D1E5B; }
-.kpi .label { color: #6b7280; font-size: 14px; }
+  .kpi-card .val   { font: 600 28px/1 'Poppins', system-ui; color: #1D1E5B; }
+  .kpi-card .label { color: #6b7280; font-size: 14px; }
 
 .charts {
   display: grid;
@@ -32,63 +32,66 @@
   .charts { grid-template-columns: 1fr; }
 }
 
-
-/* Dashboard panels (KPIs & charts) */
-.panel {
+/* --- Dashboard card hover without tinting charts --- */
+.kpi-card,
+.chart-card {
   position: relative;
-  background: #fff;
   border-radius: 16px;
-  box-shadow: 0 2px 10px rgba(0,0,0,.06);
-  transition:
-    transform 180ms cubic-bezier(.2,.0,.2,1),
-    box-shadow 180ms cubic-bezier(.2,.0,.2,1),
-    filter 180ms cubic-bezier(.2,.0,.2,1);
-  will-change: transform;
-
-  /* State layer (Material 3-esque) */
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: rgba(197, 69, 115, 0.06); /* Rym May pink @ ~6% */
-    opacity: 0;
-    transition: opacity 180ms cubic-bezier(.2,.0,.2,1);
-    pointer-events: none;
-  }
-
-  &:hover::after,
-  &:focus-within::after {
-    opacity: 1;
-  }
-
-  &:hover,
-  &:focus-within {
-    transform: translateY(-6px) scale(1.01);
-    box-shadow: 0 10px 24px rgba(29, 30, 91, 0.18); /* brand blue shadow tint */
-  }
+  overflow: hidden; /* ensures pseudo-element is clipped to card */
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.08);
+  background: #fff;
 }
 
-/* Reduce motion or touch devices – don’t animate hover */
+/* Material state-layer inspired underlay (below content) */
+.kpi-card::before,
+.chart-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(197, 69, 115, 0.06);
+  opacity: 0;
+  z-index: 0;            /* under content */
+  transition: opacity 180ms ease;
+}
+
+.kpi-card:hover,
+.chart-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0,0,0,.12), 0 4px 12px rgba(0,0,0,.08);
+}
+.kpi-card:hover::before,
+.chart-card:hover::before { opacity: 1; }
+
+/* Charts: keep surface white and above the state layer */
+.chart-surface {
+  position: relative;
+  z-index: 1;          /* above ::before underlay */
+  background: #fff;
+  border-radius: 12px;
+}
+.echart {
+  background: #fff;    /* defensive: if canvas is transparent, container stays white */
+  border-radius: 12px;
+}
+
+/* Respect users that prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .panel {
+  .kpi-card,
+  .chart-card {
+    transition: none;
+    transform: none !important;
+  }
+  .kpi-card::before,
+  .chart-card::before {
     transition: none;
   }
-  .panel:hover,
-  .panel:focus-within {
-    transform: none;
-    box-shadow: 0 2px 10px rgba(0,0,0,.06);
-  }
-}
-@media (hover: none) {
-  .panel:hover {
-    transform: none;
-    box-shadow: 0 2px 10px rgba(0,0,0,.06);
-  }
 }
 
+
+
 /* Keep existing layout; only ensure KPI content doesn’t shift on hover */
-.kpi {
+.kpi-card {
   display: grid;
   grid-template-columns: 56px 1fr;
   align-items: center;

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -95,6 +95,7 @@ export class DashboardComponent {
 
     return {
       bar: {
+        backgroundColor: '#ffffff',
         tooltip: { trigger: 'axis' },
         xAxis:   { type: 'category', data: courseNames, axisLabel: { rotate: 25 } },
         yAxis:   { type: 'value' },
@@ -102,6 +103,7 @@ export class DashboardComponent {
         grid:    { left: 36, right: 16, bottom: 40, top: 24 },
       },
       line: {
+        backgroundColor: '#ffffff',
         tooltip: { trigger: 'axis' },
         xAxis:   { type: 'category', data: weeks },
         yAxis:   { type: 'value' },
@@ -109,6 +111,7 @@ export class DashboardComponent {
         grid:    { left: 40, right: 16, bottom: 24, top: 24 },
       },
       pie: {
+        backgroundColor: '#ffffff',
         tooltip: { trigger: 'item' },
         series: [{
           type: 'pie',


### PR DESCRIPTION
## Summary
- keep KPI and chart card hover in sync with charts
- add surface wrapper to chart cards so hover tint doesn't cover the charts
- ensure white background on ECharts canvases

## Testing
- `npx ng test --watch=false` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6889bc89440c8332969958a95a90a665