### PR TITLE
Align snackbars with Rym May brand

### DIFF
--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -103,3 +103,13 @@
 .chart-card {
   padding: 16px 18px 6px;
 }
+
+/* Defensive overflow rules */
+:host { display: block; overflow-x: hidden; }
+.kpis, .charts, .card { min-width: 0; }
+.echart {
+  width: 100%;
+  min-width: 0;
+  background: #fff;
+  border-radius: 12px;
+}

--- a/src/app/dialogs/confirm-dialog/confirm-dialog.component.scss
+++ b/src/app/dialogs/confirm-dialog/confirm-dialog.component.scss
@@ -1,4 +1,7 @@
+@use 'sass:color';
+@use '@angular/material' as mat;
 @use '../../../styles/layout';
+@use '../../../styles/rym-theme' as *;
 
 .dialog-title{
   font-family: 'Barlow Semi Condensed', sans-serif;
@@ -7,4 +10,5 @@
   color: #1D1E5B;
 }
 .dialog-content{ padding: layout.$space-2; }
+:host { .danger { color: #C54573; } }
 .dialog-actions{ padding: layout.$space-2; }

--- a/src/app/students/students.component.ts
+++ b/src/app/students/students.component.ts
@@ -100,7 +100,7 @@ export class StudentsComponent {
       createdAt: Date.now()
     };
     this.studentSvc.add(student);
-    this.snack.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-fixed' });
+    this.snack.open('¡Alumna registrada!', '', { duration: 2000, panelClass: 'snack-success' });
     this.form.reset({ courseIds: [] as any });
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,24 +22,31 @@ body { margin: 0; font-family: 'Poppins', Roboto, sans-serif; }
   -webkit-backdrop-filter: blur(4px);
 }
 
-/* ---- Brand snackbars (MDC) ---- */
-.mat-mdc-snack-bar-container.snack-success .mdc-snackbar__surface {
-  background: #1D1E5B;  /* primary */
+/* ---- Brand snackbars ---- */
+.mat-mdc-snack-bar-container.snack-success {
+  background: #1D1E5B; /* primary */
   color: #fff;
-}
-.mat-mdc-snack-bar-container.snack-warn .mdc-snackbar__surface {
-  background: #C54573;  /* accent for destructive/alert */
-  color: #fff;
-}
-/* optional: rounded shape & slight elevation */
-.mat-mdc-snack-bar-container.snack-success .mdc-snackbar__surface,
-.mat-mdc-snack-bar-container.snack-warn .mdc-snackbar__surface {
   border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0,0,0,.24);
+}
+.mat-mdc-snack-bar-container.snack-warn {
+  background: #C54573; /* hot pink */
+  color: #fff;
+  border-radius: 12px;
+}
+/* (fallback) map old 'snack-fixed' to success */
+.mat-mdc-snack-bar-container.snack-fixed { background: #1D1E5B; color: #fff; }
+
+/* Prevent horizontal scrolling on small screens */
+html, body, .mat-drawer-content, mat-sidenav-content {
+  overflow-x: hidden !important;
 }
 
-/* Global safety net to avoid stray horizontal scrollbars */
-html, body { overflow-x: hidden; }
+/* Make flex/grid children shrink properly (avoids chart overflow) */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+.echart, canvas, img, video { max-width: 100%; height: auto; }
 
 /* Ensure Material overlays (mat-select panel, menus, dialogs) sit above toolbar/sidenav */
 .cdk-overlay-container { z-index: 2000; } /* higher than any local headers */

--- a/src/styles/_rym-theme.scss
+++ b/src/styles/_rym-theme.scss
@@ -23,7 +23,7 @@ $rym-primary: mat.define-palette((
 ));
 
 $rym-accent: mat.define-palette(mat.$pink-palette, 400, 300, 600);   // hot pink
-$rym-warn  : mat.define-palette(mat.$deep-orange-palette, 600);
+$rym-warn  : mat.define-palette(mat.$pink-palette, 600, 500, 700); // brand-aligned "warn"
 
 /* 2. Theme map */
 $rym-theme: mat.define-light-theme((


### PR DESCRIPTION
## Summary
- colorize `warn` palette using brand pink
- style brand snackbars and map old class to success
- update save snackbar class to `snack-success`
- style confirm dialog with brand pink
- prevent horizontal scroll and allow charts to shrink
- add overflow fixes for dashboard

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_688af6dd0e4083328008bcd5f4aaef66