### PR TITLE
Fix dashboard layout and pie legend

### DIFF
--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,13 +1,22 @@
 :host {
   display: block;
-  padding: 24px;            /* top/bottom/left/right spacing */
+  /* a bit more breathing room under the top bar */
+  padding: clamp(20px, 3.5vw, 32px);
 }
 
 .kpis {
   display: grid;
-  grid-template-columns: repeat(4, minmax(220px, 1fr));
+  /* auto-fit prevents horizontal scroll on small screens */
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
   margin-bottom: 24px;
+}
+
+@media (max-width: 1024px) {
+  .kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 600px) {
+  .kpis { grid-template-columns: 1fr; }
 }
 
 
@@ -29,6 +38,9 @@
 }
 
 @media (max-width: 1100px) {
+  .charts { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 700px) {
   .charts { grid-template-columns: 1fr; }
 }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -113,15 +113,29 @@ export class DashboardComponent {
       pie: {
         backgroundColor: '#ffffff',
         tooltip: { trigger: 'item' },
+        legend: {
+          orient: 'vertical',
+          right: 10,
+          top: 'center',
+          textStyle: { color: brandBlue },
+        },
         series: [{
           type: 'pie',
           radius: ['55%','80%'],
           avoidLabelOverlap: true,
-          label: { show: true, formatter: '{b}: {c}' },
           data: [
-            { name: 'Pagado',   value: paid,    itemStyle: { color: brandPink } },
-            { name: 'Pendiente',value: pending, itemStyle: { color: gray } },
+            { value: paid,    name: 'Pagado' },
+            { value: pending, name: 'Pendiente' },
           ],
+          label: {
+            show: true,
+            formatter: '{b}: {c}',
+            color: brandBlue,
+            fontSize: 12,
+          },
+          labelLine: { show: true, length: 12, length2: 8 },
+          itemStyle: { borderColor: '#fff', borderWidth: 2 },
+          color: [brandPink, gray],
         }],
       },
     };


### PR DESCRIPTION
## Summary
- make dashboard KPIs grid auto-fit with mobile breakpoints
- adjust dashboard top padding for breathing room
- show labels and legend on deposits pie chart

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b118f80548332b815a64171b0f095